### PR TITLE
Decompression fixes

### DIFF
--- a/cpp/lazrs_cpp.cpp
+++ b/cpp/lazrs_cpp.cpp
@@ -6,7 +6,8 @@ namespace lazrs
 LasZipDecompressor::LasZipDecompressor(const uint8_t *data,
                                        size_t size,
                                        const uint8_t *laszip_vlr_record_data,
-                                       uint16_t record_data_len)
+                                       uint16_t record_data_len,
+                                       uint64_t point_offset)
     : m_decompressor(nullptr, lazrs_decompressor_delete)
 {
     Lazrs_LasZipDecompressor *decompressor;
@@ -16,6 +17,7 @@ LasZipDecompressor::LasZipDecompressor(const uint8_t *data,
     params.source.buffer.len = size;
     params.laszip_vlr.data = laszip_vlr_record_data;
     params.laszip_vlr.len = record_data_len;
+    params.source_offset = point_offset;
     Lazrs_Result result = lazrs_decompressor_new(&decompressor, params);
     if (result != LAZRS_OK)
     {

--- a/examples/c_decompressor.c
+++ b/examples/c_decompressor.c
@@ -35,6 +35,7 @@ int main(int argc, char *argv[])
     params.laszip_vlr.len = laszip_vlr->record_len;
     params.source_type = LAZRS_SOURCE_FILE;
     params.source.file = las_file->file;
+    params.source_offset = las_file->header.offset_to_point_data;
     result = lazrs_decompressor_new(&decompressor, params);
 
     if (result != LAZRS_OK)

--- a/examples/cpp_decompressor.cpp
+++ b/examples/cpp_decompressor.cpp
@@ -33,7 +33,7 @@ int main(int argc, char *argv[])
     try
     {
         lazrs::LasZipDecompressor decompressor(
-            compressed_point_data, len, laszip_vlr->data, laszip_vlr->record_len);
+            compressed_point_data, len, laszip_vlr->data, laszip_vlr->record_len, las_file->header.offset_to_point_data);
         std::vector<uint8_t> point_data(las_file->header.point_size * sizeof(uint8_t), 0);
         for (size_t i{0}; i < las_file->header.point_count; ++i)
         {

--- a/lazrs/Cargo.toml
+++ b/lazrs/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["staticlib", "cdylib"]
 cbindgen = "0.20.0"
 
 [dependencies]
-laz = "^0.5.2"
+laz = "^0.6.0"
 libc = "^0.2.86"

--- a/lazrs/include/lazrs/lazrs_cpp.h
+++ b/lazrs/include/lazrs/lazrs_cpp.h
@@ -10,7 +10,8 @@ class LasZipDecompressor
     LasZipDecompressor(const uint8_t *data,
                        size_t size,
                        const uint8_t *laszip_vlr_record_data,
-                       uint16_t record_data_len);
+                       uint16_t record_data_len,
+                       uint64_t point_offset);
 
     void decompress_one(uint8_t *out, size_t len, Lazrs_Result &result);
     void decompress_one(uint8_t *out, size_t len);

--- a/minilas/src/las.c
+++ b/minilas/src/las.c
@@ -177,17 +177,8 @@ void print_header(const las_header *header)
 void las_file_read_all_point_data(las_file_t *las_file, uint8_t **output, size_t *len)
 {
     // TODO Err handling
-    size_t len_to_read;
-    if (las_file->header.is_data_compressed)
-    {
-        fseek(las_file->file, 0, SEEK_END);
-        long end = ftell(las_file->file);
-        len_to_read = end - las_file->header.offset_to_point_data;
-    }
-    else
-    {
-        len_to_read = las_file->header.point_size * las_file->header.point_count;
-    }
+    fseek(las_file->file, 0, SEEK_END);
+    long len_to_read = ftell(las_file->file);
 
     if (len_to_read == 0)
     {
@@ -196,7 +187,7 @@ void las_file_read_all_point_data(las_file_t *las_file, uint8_t **output, size_t
 
     *output = (uint8_t *)malloc(sizeof(uint8_t) * len_to_read);
     assert(output != NULL);
-    fseek(las_file->file, las_file->header.offset_to_point_data, SEEK_SET);
+    fseek(las_file->file, 0, SEEK_SET);
     fread(*output, sizeof(uint8_t), len_to_read, las_file->file);
     *len = len_to_read;
 }


### PR DESCRIPTION
Bump lazrs to 0.6.0 to support variable length chunks

With a `LAZRS_SOURCE_BUFFER` type, note that lazrs will not be able to read the chunk table correctly, because the offset to the chunk table will become invalid since the buffer offsets start at the beginning of the point data. I.e. if the offset to point data is 475, and we read from 475 to the end of the file, then the chunk table offset that we read in is incorrect by 475 bytes (since the length of the buffer is `size of the file - 475` now). 

To fix this, we can read the entire file into the buffer, not just the point data. However, we still need a way to seek to the beginning of the point data. Since we can't seek within an array in C, we have to do it after we create `csource`, thus we pass in the point data offset as a parameter. These changes will fix the `cpp_decompressor`, which uses `LAZRS_SOURCE_BUFFER`. 

With `LAZRS_SOURCE_FILE`, which `c_decompressor` uses, we were able to seek to the beginning of the point data while also keeping the absolute offset positions in the file consistent, thus it didn't run into this issue.

Closes #5 